### PR TITLE
Fixed bug in current_user method of token_authenticatable controller.

### DIFF
--- a/lib/token_authenticate_me/concerns/controllers/token_authenticateable.rb
+++ b/lib/token_authenticate_me/concerns/controllers/token_authenticateable.rb
@@ -17,7 +17,7 @@ module TokenAuthenticateMe
         end
 
         def current_user
-          return @current_user if authenticate_token
+          return unless authenticate_token
           @current_user ||= User.find_by_id(authenticate_token.user_id)
         end
 


### PR DESCRIPTION
the variable current user wasn't being set, so current user would always return nil. Fixed it to now check the token, then set @current_user if needs be.