### PR TITLE
added destroy dependency to Authenticatable model

### DIFF
--- a/lib/token_authenticate_me/concerns/models/authenticatable.rb
+++ b/lib/token_authenticate_me/concerns/models/authenticatable.rb
@@ -10,7 +10,7 @@ module TokenAuthenticateMe
           has_secure_password validations: false
           attr_accessor :current_password
 
-          has_many :sessions
+          has_many :sessions, dependent: :destroy
           has_many :invites, inverse_of: 'creator', foreign_key: 'creator_id'
 
           validates(


### PR DESCRIPTION
adds `dependent: destroy` to Authenticatable model's `has_many :sessions` relationship.