### PR TITLE
Makes username/email case insensitive

### DIFF
--- a/db/migrate/20180123184510_downcase_username_email.rb
+++ b/db/migrate/20180123184510_downcase_username_email.rb
@@ -1,0 +1,12 @@
+class DowncaseUsernameEmail < ActiveRecord::Migration
+  class TokenAuthenticateMe::User < ActiveRecord::Base
+  end
+
+  def change
+    TokenAuthenticateMe::User.find_each do |user|
+      user.username = user.username.downcase
+      user.email = user.email.downcase
+      user.save!(validate: false)
+    end
+  end
+end

--- a/lib/token_authenticate_me/concerns/controllers/sessionable.rb
+++ b/lib/token_authenticate_me/concerns/controllers/sessionable.rb
@@ -20,8 +20,12 @@ module TokenAuthenticateMe
             Session.create!(user_id: authenticated_resource.id)
           end
 
+          def username
+            session_params[:username].blank? ? '' : session_params[:username].downcase
+          end
+
           def resource
-            @resource ||= User.where('username=? OR email=?', session_params[:username], session_params[:username]).first
+            @resource ||= User.where('lower(username)=? OR lower(email)=?', username, username).first
           end
 
           def authenticate_resource

--- a/lib/token_authenticate_me/concerns/models/authenticatable.rb
+++ b/lib/token_authenticate_me/concerns/models/authenticatable.rb
@@ -6,12 +6,14 @@ module TokenAuthenticateMe
     module Models
       module Authenticatable
         extend ActiveSupport::Concern
-          include TokenAuthenticateMe::Concerns::Models::Passwordable
+        include TokenAuthenticateMe::Concerns::Models::Passwordable
 
         included do
 
           has_many :sessions, dependent: :destroy
           has_many :invites, inverse_of: 'creator', foreign_key: 'creator_id'
+
+          before_save :downcase_email_and_username
 
           validates(
             :email,
@@ -42,6 +44,13 @@ module TokenAuthenticateMe
 
           def as_json(options = nil)
             { user: super(options) }
+          end
+
+          protected
+
+          def downcase_email_and_username
+            self.email = email.downcase
+            self.username = username.downcase
           end
         end
       end


### PR DESCRIPTION
This adds a migration to downcase all username/emails. It also adds a
before_save hook to downcase email/usernames. Last but not least, it
adds an extra saftey measure of `lower(username) OR lower(email)` to the
SQL query and to the username/email sent for login. Only way this would
ever conflict is if the migration is not installed and two users have
the same email or username.